### PR TITLE
Fix: supports file arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tmp
 pkg
 *.gem
 tslurper_config.yml
+.ruby-version
+vendor/ruby/

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gemspec
 
 gem 'configuration'
 gem 'pry'
+gem 'pry-byebug'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,13 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     coderay (1.1.0)
+    columnize (0.9.0)
     configuration (1.3.4)
+    debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     ethon (0.7.3)
       ffi (>= 1.3.0)
@@ -28,6 +33,9 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-byebug (1.3.2)
+      byebug (~> 2.7)
+      pry (~> 0.9.12)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -49,5 +57,6 @@ PLATFORMS
 DEPENDENCIES
   configuration
   pry
+  pry-byebug
   rspec
   trello_slurper!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trello_slurper (0.0.1)
+    trello_slurper (0.0.2)
       activesupport (~> 4.1)
       typhoeus (~> 0.6)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trello_slurper (0.0.2)
+    trello_slurper (0.0.3)
       activesupport (~> 4.1)
       typhoeus (~> 0.6)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require "bundler/gem_tasks"
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = "spec/**/*_spec.rb"

--- a/bin/tslurp
+++ b/bin/tslurp
@@ -1,16 +1,15 @@
 #!/usr/bin/env ruby
 
 # Slurps stories from the given file (stories.slurper by default) and creates
-# Pivotal Tracker stories from them. Useful during story carding sessions
+# Trello story cards from them. Useful during story carding sessions
 # when you want to capture a number of stories quickly without clicking
-# your way through the Tracker UI.
+# your way through the Trello UI.
 
 # Default story values and API token information should be provided in a
-# ~/.slurper.yml file.
+# tslurper_config.yml file.
 
-# Note that if you include labels in stories.slurper, they don't appear
-# immediately in Tracker. You'll have to refresh Tracker after a few seconds
-# to see them.
+# Note that if you include labels in stories.slurper, they aren't currently
+# supported and will be ignored.
 
 $:.unshift(File.join(File.dirname(File.dirname(__FILE__)),'lib'))
 require 'rubygems'
@@ -18,15 +17,46 @@ require 'slurper'
 require 'optparse'
 
 options = {}
-OptionParser.new do |opts|
+args = OptionParser.new do |opts|
   opts.on("-r", "--reverse", "Reverse story creation order") do |v|
     options[:reverse] = v
   end
+  opts.on("-t", "--create-token", "Request a new write token from Trello") do |v|
+    options[:token] = v
+  end
+  opts.on("-f", "--story-file FILE", "Story File to slurp, defaults to stories.slurper") do |v|
+    options[:story_file] = v
+  end
+  opts.on("-h", "--help", "Show help for tslurp") do
+    puts opts
+    exit
+  end
 end.parse!
 
-story_file = ARGV.empty? ? "stories.slurper" : ARGV[0]
-if File.file?(story_file)
+# capture file passed w/o -f/--story-file flag
+if args.any?
+  options[:story_file] ||= args.first
+end
+
+begin
+  if options[:token] || Slurper::Config.trello_write_token.blank?
+    client = Slurper::Client.new
+    token = client.get_trello_write_token
+    if token.blank?
+      raise "No token was provided. Exiting..."
+    else
+      puts "Your tslurper_config.yml has been updated with the new token."
+    end
+  end
+
+  story_file = options.fetch(:story_file, "stories.slurper")
+  raise "#{story_file} does not exist" unless File.file?(story_file)
+  raise "Configuration is not valid\n#{Slurper::Config.errors}" unless Slurper::Config.valid?
+
   Slurper.slurp(story_file, options[:reverse])
-else
-  puts "#{story_file} does not exist"
+rescue => e
+  puts '=' * 80
+  puts e.message
+  puts e.backtrace
+  puts '=' * 80
 end

--- a/bin/tslurp
+++ b/bin/tslurp
@@ -25,5 +25,8 @@ OptionParser.new do |opts|
 end.parse!
 
 story_file = ARGV.empty? ? "stories.slurper" : ARGV[0]
-
-Slurper.slurp(story_file, options[:reverse])
+if File.file?(story_file)
+  Slurper.slurp(story_file, options[:reverse])
+else
+  puts "#{story_file} does not exist"
+end

--- a/lib/slurper/client.rb
+++ b/lib/slurper/client.rb
@@ -5,13 +5,17 @@ module Slurper
     attr_reader :write_token, :list_id
 
     def get_trello_write_token
-      url = "https://trello.com/1/authorize?key=#{Slurper::Config.trello_application_key}&name=Slurper%20for%20Trello&expiration=1day&response_type=token&scope=read%2Cwrite"
-      puts "You must provide a write-enabled Trello API token."
-      puts "Ensure you're logged into Trello, then press the <ENTER> key to open a browser window to fetch this token."
-      _ = gets
-      `open "#{url}"`
-      puts "Please paste your token."
-      @write_token = gets.strip
+      if Slurper::Config.trello_write_token.present?
+        @write_token = Slurper::Config.trello_write_token
+      else
+        url = "https://trello.com/1/authorize?key=#{Slurper::Config.trello_application_key}&name=Slurper%20for%20Trello&expiration=1day&response_type=token&scope=read%2Cwrite"
+        puts "You must provide a write-enabled Trello API token."
+        puts "Ensure you're logged into Trello, then press the <ENTER> key to open a browser window to fetch this token."
+        _ = gets
+        `open "#{url}"`
+        puts "Please paste your token."
+        @write_token = gets.strip
+      end
     end
 
     def create_list
@@ -22,6 +26,12 @@ module Slurper
     def create_card(story)
       url = "https://trello.com/1/lists/#{list_id}/cards?key=#{Slurper::Config.trello_application_key}&token=#{write_token}"
       Typhoeus.post url, body: story.to_post_params
+    end
+
+    def validate_write_token
+      url = "https://trello.com/1/tokens/#{write_token}?key=#{Slurper::Config.trello_application_key}"
+      response = Typhoeus.get(url).body.strip
+      raise "Invalid Token '#{write_token}'" if response =~ /invalid token/
     end
   end
 end

--- a/lib/slurper/client.rb
+++ b/lib/slurper/client.rb
@@ -4,17 +4,26 @@ module Slurper
   class Client
     attr_reader :write_token, :list_id
 
-    def get_trello_write_token
-      if Slurper::Config.trello_write_token.present?
-        @write_token = Slurper::Config.trello_write_token
-      else
-        url = "https://trello.com/1/authorize?key=#{Slurper::Config.trello_application_key}&name=Slurper%20for%20Trello&expiration=1day&response_type=token&scope=read%2Cwrite"
-        puts "You must provide a write-enabled Trello API token."
-        puts "Ensure you're logged into Trello, then press the <ENTER> key to open a browser window to fetch this token."
-        _ = gets
-        `open "#{url}"`
-        puts "Please paste your token."
-        @write_token = gets.strip
+    def initialize
+      @write_token = Slurper::Config.trello_write_token
+    end
+
+    def get_trello_write_token(overwrite_config=true)
+      url = "https://trello.com/1/authorize?key=#{Slurper::Config.trello_application_key}&name=Slurper%20for%20Trello&expiration=30days&response_type=token&scope=read%2Cwrite"
+      puts "You must provide a write-enabled Trello API token."
+      puts "Ensure you're logged into Trello, then press the <ENTER> key to open a browser window to fetch this token."
+      _ = gets
+      `open "#{url}"`
+      puts "Please paste your token."
+      @write_token = gets.strip
+
+      # =================================================================================
+      # BUG: When a file name is passed, the gets.strip somehow picks up 'story_type:'.
+      # This causes the script to continue executing, but creates an invalid write token
+      # =================================================================================
+
+      if overwrite_config == true && write_token =~ /^[a-zA-Z0-9]{50,70}$/
+        Slurper::Config.store(:trello_write_token, write_token)
       end
     end
 
@@ -32,6 +41,11 @@ module Slurper
       url = "https://trello.com/1/tokens/#{write_token}?key=#{Slurper::Config.trello_application_key}"
       response = Typhoeus.get(url).body.strip
       raise "Invalid Token '#{write_token}'" if response =~ /invalid token/
+
+      token_data = JSON.parse(response)
+      date_created = Time.parse(token_data['dateCreated'])
+      date_expires = Time.parse(token_data['dateExpires'])
+      puts "-- token valid from #{date_created} to #{date_expires}"
     end
   end
 end

--- a/lib/slurper/config.rb
+++ b/lib/slurper/config.rb
@@ -4,6 +4,7 @@ module Slurper
 
     def self.trello_application_key; @trello_application_key ||= yaml['trello_application_key'] end
     def self.trello_board_id; @trello_board_id ||= yaml['trello_board_id'] end
+    def self.trello_write_token; @trello_write_token ||= yaml['trello_write_token'] end
 
     private
 

--- a/lib/slurper/config.rb
+++ b/lib/slurper/config.rb
@@ -6,10 +6,33 @@ module Slurper
     def self.trello_board_id; @trello_board_id ||= yaml['trello_board_id'] end
     def self.trello_write_token; @trello_write_token ||= yaml['trello_write_token'] end
 
+    def self.valid?
+      !trello_application_key.blank? &&
+      !trello_board_id.blank? &&
+      !trello_write_token.blank?
+    end
+
+    def self.errors
+      [].tap do |errors|
+        errors << ":trello_application_key is required" if trello_application_key.blank?
+        errors << ":trello_board_id is required" if trello_board_id.blank?
+        errors << ":trello_write_token is required" if trello_write_token.blank?
+      end
+    end
+
+    def self.to_s
+      yaml.to_s
+    end
+
+    def self.store(key, value)
+      yaml[key.to_s] = value.to_s
+      File.open("tslurper_config.yml", 'w') { |f| YAML.dump(yaml, f) }
+    end
+
     private
 
     def self.yaml
-      YAML.load_file('tslurper_config.yml')
+      @yaml ||= YAML.load_file('tslurper_config.yml')
     end
 
   end

--- a/lib/slurper/engine.rb
+++ b/lib/slurper/engine.rb
@@ -6,11 +6,6 @@ module Slurper
     def initialize(*args)
       super(*args)
       @client = Slurper::Client.new
-      @client.get_trello_write_token
-      @client.validate_write_token
-      @client.create_list
-    rescue => e
-      puts e
     end
 
     def stories
@@ -20,6 +15,12 @@ module Slurper
     def process
       puts "Validating story content"
       stories.each(&:valid?)
+
+      puts "Validating write access to Trello Board"
+      client.validate_write_token
+
+      puts "Creating Slurper Import List"
+      client.create_list
 
       puts "Preparing to slurp #{stories.size} stories into Trello..."
       stories.each_with_index do |story, index|

--- a/lib/slurper/engine.rb
+++ b/lib/slurper/engine.rb
@@ -7,7 +7,10 @@ module Slurper
       super(*args)
       @client = Slurper::Client.new
       @client.get_trello_write_token
+      @client.validate_write_token
       @client.create_list
+    rescue => e
+      puts e
     end
 
     def stories

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler'
+require 'slurper'
 
 Bundler.require(:default, :development)
 

--- a/trello_slurper.gemspec
+++ b/trello_slurper.gemspec
@@ -2,12 +2,12 @@
 
 Gem::Specification.new do |gem|
   gem.name = "trello_slurper"
-  gem.version = "0.0.2"
+  gem.version = "0.0.3"
   gem.license = "MIT"
 
-  gem.authors = ["Adam Lowe", "Paul Elliott", "Taylor Mock", "Nickolas Means"]
+  gem.authors = ["Adam Lowe", "Paul Elliott", "Taylor Mock", "Nickolas Means", "Jason Cartwright"]
   gem.default_executable = 'tslurp'
-  gem.description = "Slurps stories from the given file (stories.slurper by default) and creates Trello cards from them. Useful during story carding sessions when you want to capture a number of stories quickly without clicking your way through the Tracker UI."
+  gem.description = "Slurps stories from the given file (stories.slurper by default) and creates Trello cards from them. Useful during story carding sessions when you want to capture a number of stories quickly without clicking your way through the Trello UI."
   gem.email = "dev@wellmatchhealth.com"
   gem.executables = ["tslurp"]
   gem.extra_rdoc_files = ["README.rdoc"]

--- a/tslurper_config.yml.example
+++ b/tslurper_config.yml.example
@@ -5,3 +5,8 @@ trello_application_key: 123abc123abc123abc123abc
 # Trello board id is the 8 character string after /b/ in the board url.
 # Ex. '1a2abcdc' is the board id in https://trello.com/b/1a2abcdc/test-board
 trello_board_id: 1a2abcdc
+
+# Trello requires a write-enabled token in order to create lists and stories.
+# According to the API docs, you can request a "forever" token, or set an
+# expiration length in the request to generate the token.
+trello_write_token: 9870abcd9870abcd9807abcd


### PR DESCRIPTION
The root of the bug was calling $ tslurp with a filename like this `$ tslurp foo.slurper` would fail because the script always required the generation of a trello write token using the open 'url/to/generate/token' in a browser. The script would fall through and not properly _block_ to wait for the user to paste in their new token. The solution for this is to...
1. Separate the workflow for Token Generation from Story Creation
2. Persist the write token in config so the user isn't prompted for a new one every time you run the script
3. Allow the story file to be the only arg, or be an explicit option with the -f/--story-file flag

I also added some validation and improved messaging for the Config to guide users to a solution when something isn't right. And, I added -h/--help options to provide some useful documentation for usage.
